### PR TITLE
Add summarize key-file shell wrappers

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -116,3 +116,7 @@ fish_add_path "$PNPM_HOME/bin"
 if command -q sag
     set -gx ELEVENLABS_API_KEY_FILE "$HOME/.config/sag/elevenlabs.key"
 end
+
+if command -q summarize; and not set -q SUMMARIZE_OPENAI_API_KEY_FILE
+    set -gx SUMMARIZE_OPENAI_API_KEY_FILE "$HOME/.config/summarize/openai.key"
+end

--- a/.config/fish/functions/summarize.fish
+++ b/.config/fish/functions/summarize.fish
@@ -1,0 +1,37 @@
+function summarize --wraps summarize
+    if not command -q summarize
+        echo "summarize: command not found. Install summarize first." >&2
+        return 127
+    end
+
+    if not set -q OPENAI_API_KEY
+        if not set -q SUMMARIZE_OPENAI_API_KEY_FILE
+            echo "summarize: SUMMARIZE_OPENAI_API_KEY_FILE is not set. Expected $HOME/.config/summarize/openai.key" >&2
+            return 1
+        end
+
+        if not test -r "$SUMMARIZE_OPENAI_API_KEY_FILE"
+            echo "summarize: SUMMARIZE_OPENAI_API_KEY_FILE points to a missing or unreadable file: $SUMMARIZE_OPENAI_API_KEY_FILE" >&2
+            return 1
+        end
+
+        set -l perms (stat -f %Lp "$SUMMARIZE_OPENAI_API_KEY_FILE" 2>/dev/null; or stat -c %a "$SUMMARIZE_OPENAI_API_KEY_FILE" 2>/dev/null)
+        if test -n "$perms"
+            set -l group_digit (string sub -s -2 -l 1 -- "$perms")
+            set -l other_digit (string sub -s -1 -l 1 -- "$perms")
+            if test "$group_digit" != 0; or test "$other_digit" != 0
+                echo "summarize: warning: $SUMMARIZE_OPENAI_API_KEY_FILE permissions are $perms; consider chmod 600 $SUMMARIZE_OPENAI_API_KEY_FILE" >&2
+            end
+        end
+
+        set -l api_key
+        if not read -l api_key < "$SUMMARIZE_OPENAI_API_KEY_FILE"; or test -z "$api_key"
+            echo "summarize: SUMMARIZE_OPENAI_API_KEY_FILE is empty: $SUMMARIZE_OPENAI_API_KEY_FILE" >&2
+            return 1
+        end
+
+        set -lx OPENAI_API_KEY "$api_key"
+    end
+
+    command summarize $argv
+end

--- a/.zshrc
+++ b/.zshrc
@@ -301,6 +301,45 @@ if (( $+commands[sag] )); then
   }
 fi
 
+if (( $+commands[summarize] )); then
+  export SUMMARIZE_OPENAI_API_KEY_FILE="${SUMMARIZE_OPENAI_API_KEY_FILE:-$HOME/.config/summarize/openai.key}"
+  typeset -g _summarize_command="${commands[summarize]}"
+
+  summarize() {
+    local key_file="${SUMMARIZE_OPENAI_API_KEY_FILE:-}"
+
+    if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+      if [[ -z "$key_file" ]]; then
+        print -u2 "summarize: SUMMARIZE_OPENAI_API_KEY_FILE is not set. Expected $HOME/.config/summarize/openai.key"
+        return 1
+      fi
+
+      if [[ ! -r "$key_file" ]]; then
+        print -u2 "summarize: SUMMARIZE_OPENAI_API_KEY_FILE points to a missing or unreadable file: $key_file"
+        return 1
+      fi
+
+      local perms
+      perms="$(stat -f %Lp "$key_file" 2>/dev/null || stat -c %a "$key_file" 2>/dev/null)"
+      if [[ -n "$perms" && ( "${perms[-2]}" != "0" || "${perms[-1]}" != "0" ) ]]; then
+        print -u2 "summarize: warning: $key_file permissions are $perms; consider chmod 600 $key_file"
+      fi
+
+      local api_key
+      api_key="$(<"$key_file")"
+      if [[ -z "$api_key" ]]; then
+        print -u2 "summarize: SUMMARIZE_OPENAI_API_KEY_FILE is empty: $key_file"
+        return 1
+      fi
+
+      OPENAI_API_KEY="$api_key" command "$_summarize_command" "$@"
+      return
+    fi
+
+    command "$_summarize_command" "$@"
+  }
+fi
+
 # Local, machine-specific overrides.
 if [[ -o interactive ]]; then
   alias cy='codex --yolo'


### PR DESCRIPTION
## Summary
- Add zsh and Fish wrappers that read OPENAI_API_KEY from SUMMARIZE_OPENAI_API_KEY_FILE when needed.
- Set a Fish default key-file path for summarize when the command is installed.

## Verification
- `stow -nv .`
- `stow -v .`
- `zsh -n .zshrc`
- `fish -n .config/fish/config.fish`
- `fish -n .config/fish/functions/summarize.fish`
- `make test`
